### PR TITLE
Import ansible module_utils before others.

### DIFF
--- a/nexus
+++ b/nexus
@@ -65,12 +65,12 @@ EXAMPLES = '''
     extension=jar
 '''
 
+from ansible.module_utils.basic import *
 import urllib2
 import base64
 from datetime import datetime
 from wsgiref.handlers import format_date_time
 import xml.etree.ElementTree as ET
-from ansible.module_utils.basic import *
 
 
 def loadArtifact(url, dest, http_user, http_pass, force):


### PR DESCRIPTION
Fixes "AttributeError: 'module' object has no attribute 'fromtimestamp'" error with ansible 2.0.1.0

Think this was introduced with 0b92abaf67de53349bb4d2733f49750d9a4d8277 where datetime was imported in that module.

It'd probably be a better solution to import individual functions from module_utils as needed, but just reordering fixes the immediate issue?