### PR TITLE
BOOLEANS are not in basic in ansible 2.5

### DIFF
--- a/nexus
+++ b/nexus
@@ -71,6 +71,7 @@ EXAMPLES = '''
 '''
 
 from ansible.module_utils.basic import *
+from ansible.module_utils.parsing.convert_bool import *
 import urllib2
 import base64
 from datetime import datetime


### PR DESCRIPTION
This pull request to make nexus ansible 2.5 ready.

you can blame : https://github.com/ansible/ansible/commit/2f36b9e5ce0ec41a822752845d3b7c4afdf7eee9#diff-90085fdcec6ed8b273ba885eaee60328L173